### PR TITLE
correctly defines markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # nycmeshnet.github.io
 
-Our website [https://nycmesh.net]()
+Our website [https://nycmesh.net](https://nycmesh.net)
 
 # How its built
 
-The site is run on [jekyll](jekyllrb.net), hosted by github
+The site is run on [jekyll](https://jekyllrb.net), hosted by github
 
 To test locally, `gem install jekyll`, and `jekyll serve`
 
@@ -15,6 +15,6 @@ doesn't like open communities. Its a user, pretending to be a bot.
 
 The user is called @slackin, and email is slackin@[our domain]
 
-The backend and frontend code is a [now.sh]() deployment, ran by [@jedahan](https://github.com/jedahan)
+The backend and frontend code is a [now.sh](https://zeit.co/) deployment, ran by [@jedahan](https://github.com/jedahan)
 
 Domain name TXT records control the slack.nycmesh.net subdomain pointing to this instance, so it can be changed over by anyone with control over the DNS records.


### PR DESCRIPTION
This fixes up the few markdown links in the README